### PR TITLE
Remove the polyfill package from the composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
   },
   "require": {
     "php": ">=7.4",
+    "ext-mbstring": "*",  
+    "ext-ctype": "*", 
     "composer/installers": "~1.0",
     "illuminate/support": "5.6.*",
     "joachim-n/case-converter": "^1.0",
@@ -33,6 +35,11 @@
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.8.0",
     "symfony/var-dumper": "^4.2"
+  },
+  "replace": {
+    "symfony/polyfill-mbstring": "*",
+    "symfony/polyfill-ctype": "*",  
+    "ralouphie/getallheaders": "*"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
I've added some lines to composer.json. Now after "composer install" command the polyfill packages should not be installed anymore, and the SVN error should disappear.
Of course before uploading it by SVG, you have to make the "yarn && yarn build" command.