### PR TITLE
Test mode generates delivery note, template filterable, tracking code in custom field

### DIFF
--- a/src/Note/Note.php
+++ b/src/Note/Note.php
@@ -5,6 +5,8 @@ namespace Planzer\Note;
 use WC_Order;
 use Planzer\Note\Interfaces\Note as NoteInterface;
 
+use function Planzer\isTestModelEnabled;
+
 class Note
 {
   private NoteInterface $note;
@@ -41,6 +43,10 @@ class Note
             default:
                 $subject = __('Planzer note for order', 'planzer');
                 break;
+          }
+          
+          if (isTestModelEnabled()) {
+            $subject .= '[TEST MODE]';
           }
 
           $subject .= " {$this->note->getReferenceNumber()}";

--- a/src/Note/Templates/Template.php
+++ b/src/Note/Templates/Template.php
@@ -8,7 +8,9 @@ class Template
   {
     ob_start();
 
-    include PLANZER_RESOURCES_PATH . "/views/$template_name.php";
+    $default_template_path = PLANZER_RESOURCES_PATH . "/views/";
+    $template_path = apply_filters('planzer_note_template_path', $default_template_path);
+    include $template_path . $template_name . ".php";
 
     return ob_get_clean();
   }

--- a/src/Package/Package.php
+++ b/src/Package/Package.php
@@ -5,6 +5,8 @@ namespace Planzer\Package;
 use Planzer\QRCode\Counter as QRCounter;
 use Planzer\QRCode\QRCode;
 
+use function Planzer\isTestModelEnabled;
+
 class Package
 {
   private const QR_PREFIX = 91;
@@ -16,7 +18,12 @@ class Package
   public function __construct(int $order_id)
   {
     $this->order_id = $order_id;
-    $this->sequence_number = QRCounter::getQRNumber();
+    
+    if (isTestModelEnabled()) {
+      $this->sequence_number = 00000;
+    } else {
+      $this->sequence_number = QRCounter::getQRNumber();
+    }
   }
 
   public function getPackageNumber(int $width = 20): string

--- a/src/WooCommerce/Submodules/BulkAction.php
+++ b/src/WooCommerce/Submodules/BulkAction.php
@@ -75,12 +75,19 @@ class BulkAction
       }
 
       if (isTestModelEnabled()) {
-        $order->add_order_note('<span style="color:#0070ff;font-weight: bold;">Planzer: </span>' . __('Test mode enabled - data not sent', 'planzer'));
+        $package = new Package($order_id);
+        update_post_meta($order_id, 'planzer_tracking_code', 'TEST_'.$package->getQRContentWithoutSuffix());
+        $note = NoteFactory::create($order, $package, get_option('planzer_delivery_generate_note', 'label_note'));
+        if (is_a($note, Note::class)) {
+          $note->sendPdf($note->generatePDF());
+        }      
+        $order->add_order_note('<span style="color:#0070ff;font-weight: bold;">Planzer: </span>' . __('Test mode enabled - data not sent to Planzer. Demo delivery note generated and sent.', 'planzer'));
         return $redirectTo;
       }
 
       $order_note = __('Planzer: CSV generated.', 'planzer');
       $package = new Package($id);
+      update_post_meta($id, 'planzer_tracking_code', $package->getQRContentWithoutSuffix());
 
       $note = NoteFactory::create($order, $package, get_option('planzer_delivery_generate_note', 'label_note'));
       if (is_a($note, Note::class)) {

--- a/src/WooCommerce/Submodules/OrderAction.php
+++ b/src/WooCommerce/Submodules/OrderAction.php
@@ -46,12 +46,19 @@ class OrderAction
     }
 
     if (isTestModelEnabled()) {
-      $order->add_order_note('<span style="color:#0070ff;font-weight: bold;">Planzer: </span>' . __('Test mode enabled - data not sent', 'planzer'));
+      $package = new Package($order_id);
+      update_post_meta($order_id, 'planzer_tracking_code', 'TEST_'.$package->getQRContentWithoutSuffix());
+      $note = NoteFactory::create($order, $package, get_option('planzer_delivery_generate_note', 'label_note'));
+      if (is_a($note, Note::class)) {
+        $note->sendPdf($note->generatePDF());
+      }      
+      $order->add_order_note('<span style="color:#0070ff;font-weight: bold;">Planzer: </span>' . __('Test mode enabled - data not sent to Planzer. Demo delivery note generated and sent.', 'planzer'));
       return;
     }
 
     $order_note = __('Planzer: CSV generated.', 'planzer');
     $package = new Package($order_id);
+    update_post_meta($order_id, 'planzer_tracking_code', $package->getQRContentWithoutSuffix());
 
     $note = NoteFactory::create($order, $package, get_option('planzer_delivery_generate_note', 'label_note'));
     if (is_a($note, Note::class)) {

--- a/src/WooCommerce/Submodules/OrderStatus.php
+++ b/src/WooCommerce/Submodules/OrderStatus.php
@@ -102,12 +102,19 @@ class OrderStatus
     }
 
     if (isTestModelEnabled()) {
-      $order->add_order_note('<span style="color:#0070ff;font-weight: bold;">Planzer: </span>' . __('Test mode enabled - data not sent', 'planzer'));
+      $package = new Package($order_id);
+      update_post_meta($order_id, 'planzer_tracking_code', 'TEST_'.$package->getQRContentWithoutSuffix());
+      $note = NoteFactory::create($order, $package, get_option('planzer_delivery_generate_note', 'label_note'));
+      if (is_a($note, Note::class)) {
+        $note->sendPdf($note->generatePDF());
+      }      
+      $order->add_order_note('<span style="color:#0070ff;font-weight: bold;">Planzer: </span>' . __('Test mode enabled - data not sent to Planzer. Demo delivery note generated and sent.', 'planzer'));
       return;
     }
 
     $order_note = __('Planzer: CSV generated.', 'planzer');
     $package = new Package($order_id);
+    update_post_meta($order_id, 'planzer_tracking_code', $package->getQRContentWithoutSuffix());
 
     $note = NoteFactory::create($order, $package, get_option('planzer_delivery_generate_note', 'label_note'));
     if (is_a($note, Note::class)) {


### PR DESCRIPTION
Added a few improvements:
- Test mode generates a demo delivery note and sends it with [TEST MODE] in subject line
- Delivery note template path is now filterable to allow custom templates
- Custom field "planzer_tracking_code" with the tracking code is set in the order (for using it in confirmation emails)

To override the templates create a simple plugin with the following contents:
```
 // Place the new template files in: ./note/delivery-note/content.php and ./note/delivery-note/footer.php
 function custom_planzer_note_template_path() {
	 return plugin_dir_path(__FILE__);
 }
 add_filter('planzer_note_template_path', 'custom_planzer_note_template_path');
```
