### PR TITLE
Fix fatal error when bulk update orders

### DIFF
--- a/src/WooCommerce/Submodules/BulkAction.php
+++ b/src/WooCommerce/Submodules/BulkAction.php
@@ -43,8 +43,10 @@ class BulkAction
   /**
    * @filter handle_bulk_actions-edit-shop_order
    */
-  public function handlePlanzerTransmitBulkAction(string $redirectTo, string $action, array $postIds): string
+  public function handlePlanzerTransmitBulkAction(?string $redirectTo, string $action, array $postIds): string
   {
+    $redirectTo = $redirectTo ?? admin_url('edit.php?post_type=shop_order');
+
     if ('wc-planzer-transmit' !== $action) {
       return $redirectTo;
     }


### PR DESCRIPTION
`$redirectTo` args was passed as null which caused fatal error when bulk updating orders, the method now accepts null and defaults to the orders list admin page